### PR TITLE
Remove duplicated states and nest selectors instead

### DIFF
--- a/components/footer.md
+++ b/components/footer.md
@@ -13,11 +13,11 @@
 			</h2>
 			<div class="global-footer__fandom-sections">
 				<section class="global-footer__fandom-section is-fandom-overview">
-					<ul class="global-footer__links is-fandom-overview">
+					<ul class="global-footer__links">
 						<li class="global-footer__list-item">
 							<a href="#" class="global-footer__branded is-games">
 								<div>Games</div>
-								<svg class="global-footer__image is-fandom-overview icon">
+								<svg class="global-footer__image icon">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow"></use>
 								</svg>
 							</a>
@@ -25,7 +25,7 @@
 						<li class="global-footer__list-item">
 							<a href="#" class="global-footer__branded is-movies">
 								<div>Movies</div>
-								<svg class="global-footer__image is-fandom-overview icon">
+								<svg class="global-footer__image icon">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow"></use>
 								</svg>
 							</a>
@@ -33,7 +33,7 @@
 						<li class="global-footer__list-item">
 							<a href="#" class="global-footer__branded is-tv">
 								<div>TV</div>
-								<svg class="global-footer__image is-fandom-overview icon">
+								<svg class="global-footer__image icon">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow"></use>
 								</svg>
 							</a>
@@ -41,7 +41,7 @@
 						<li class="global-footer__list-item">
 							<a href="#" class="global-footer__branded is-fan-communities">
 								<div>Fan Communities</div>
-								<svg class="global-footer__image is-fandom-overview icon">
+								<svg class="global-footer__image icon">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow"></use>
 								</svg>
 							</a>
@@ -50,38 +50,38 @@
 				</section>
 				<section class="global-footer__fandom-section is-follow-us">
 					<h3 class="global-footer__section-header">Follow Us</h3>
-					<ul class="global-footer__links is-follow-us">
+					<ul class="global-footer__links">
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Facebook">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Facebook">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-facebook-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Twitter">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Twitter">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-twitter-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Reddit">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Reddit">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-reddit-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Youtube">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Youtube">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-youtube-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Instagram">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Instagram">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-instagram-default"></use>
 								</svg>
 							</a>
@@ -97,30 +97,30 @@
 			<div class="global-footer__wikia-sections">
 				<section class="global-footer__wikia-section is-company-overview">
 					<h3 class="global-footer__section-header">Overview</h3>
-					<ul class="global-footer__links is-company-overview">
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">About</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">Careers</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">News</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">Contact</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">Wikia Gives Back</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">About</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Careers</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">News</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Contact</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Wikia Gives Back</a></li>
 					</ul>
 				</section>
 				<section class="global-footer__wikia-section is-site-overview">
-					<ul class="global-footer__links is-site-overview">
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">Terms Of Use</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">Privacy Policy</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">Global Sitemap</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">API</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Terms Of Use</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Privacy Policy</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Global Sitemap</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">API</a></li>
 					</ul>
 				</section>
 				<section class="global-footer__wikia-section is-community">
 					<h3 class="global-footer__section-header">Community</h3>
-					<ul class="global-footer__links is-community">
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Community Central</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Support</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Fan Contributor Program</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">WAM Score</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Help</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Community Central</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Support</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Fan Contributor Program</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">WAM Score</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Help</a></li>
 					</ul>
 				</section>
 				<section class="global-footer__wikia-section is-create-wiki">
@@ -132,17 +132,17 @@
 				<section class="global-footer__wikia-section is-community-apps">
 					<h3 class="global-footer__section-header">Community Apps</h3>
 					<span class="global-footer__section-description">Take your favorite fandoms with you and never miss a beat.</span>
-					<ul class="global-footer__links is-community-apps">
+					<ul class="global-footer__links">
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-community-apps">
-								<svg class="global-footer__image is-community-apps" alt="App Store">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image" alt="App Store">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-appstore"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-community-apps">
-								<svg class="global-footer__image is-community-apps" alt="Google Play">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image" alt="Google Play">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-googleplay"></use>
 								</svg>
 							</a>
@@ -151,9 +151,9 @@
 				</section>
 				<section class="global-footer__wikia-section is-advertise">
 					<h3 class="global-footer__section-header">Advertise</h3>
-					<ul class="global-footer__links is-advertise">
-						<li class="global-footer__list-item"><a class="global-footer__link is-advertise" href="#">Media Kit</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-advertise" href="#">Contact</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Media Kit</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Contact</a></li>
 					</ul>
 				</section>
 			</div>
@@ -176,11 +176,11 @@
 		<div class="global-footer__main">
 			<div class="global-footer__fandom-sections">
 				<section class="global-footer__fandom-section is-fandom-overview">
-					<ul class="global-footer__links is-fandom-overview">
+					<ul class="global-footer__links">
 						<li class="global-footer__list-item">
 							<a href="#" class="global-footer__branded is-fan-communities">
 								<div>Fan Communities</div>
-								<svg class="global-footer__image is-fandom-overview icon">
+								<svg class="global-footer__image icon">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow"></use>
 								</svg>
 							</a>
@@ -189,38 +189,38 @@
 				</section>
 				<section class="global-footer__fandom-section is-follow-us">
 					<h3 class="global-footer__section-header">Follow Us</h3>
-					<ul class="global-footer__links is-follow-us">
+					<ul class="global-footer__links">
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Facebook">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Facebook">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-facebook-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Twitter">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Twitter">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-twitter-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Reddit">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Reddit">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-reddit-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Youtube">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Youtube">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-youtube-default"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-follow-us">
-								<svg class="global-footer__image is-follow-us icon" alt="Instagram">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image icon" alt="Instagram">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-instagram-default"></use>
 								</svg>
 							</a>
@@ -231,30 +231,30 @@
 			<div class="global-footer__wikia-sections">
 				<section class="global-footer__wikia-section is-company-overview">
 					<h3 class="global-footer__section-header">Overview</h3>
-					<ul class="global-footer__links is-company-overview">
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">About</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">Careers</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">News</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">Contact</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-company-overview" href="#">Wikia Gives Back</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">About</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Careers</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">News</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Contact</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Wikia Gives Back</a></li>
 					</ul>
 				</section>
 				<section class="global-footer__wikia-section is-site-overview">
-					<ul class="global-footer__links is-site-overview">
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">Terms Of Use</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">Privacy Policy</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">Global Sitemap</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-site-overview" href="#">API</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Terms Of Use</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Privacy Policy</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Global Sitemap</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">API</a></li>
 					</ul>
 				</section>
 				<section class="global-footer__wikia-section is-community">
 					<h3 class="global-footer__section-header">Community</h3>
-					<ul class="global-footer__links is-community">
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Community Central</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Support</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Fan Contributor Program</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">WAM Score</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-community" href="#">Help</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Community Central</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Support</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Fan Contributor Program</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">WAM Score</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Help</a></li>
 					</ul>
 				</section>
 				<section class="global-footer__wikia-section is-create-wiki">
@@ -266,17 +266,17 @@
 				<section class="global-footer__wikia-section is-community-apps">
 					<h3 class="global-footer__section-header">Community Apps</h3>
 					<span class="global-footer__section-description">Take your favorite fandoms with you and never miss a beat.</span>
-					<ul class="global-footer__links is-community-apps">
+					<ul class="global-footer__links">
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-community-apps">
-								<svg class="global-footer__image is-community-apps" alt="App Store">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image" alt="App Store">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-appstore"></use>
 								</svg>
 							</a>
 						</li>
 						<li class="global-footer__list-item">
-							<a href="#" class="global-footer__link is-community-apps">
-								<svg class="global-footer__image is-community-apps" alt="Google Play">
+							<a href="#" class="global-footer__link">
+								<svg class="global-footer__image" alt="Google Play">
 									<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-googleplay"></use>
 								</svg>							
 							</a>
@@ -285,9 +285,9 @@
 				</section>
 				<section class="global-footer__wikia-section is-advertise">
 					<h3 class="global-footer__section-header">Advertise</h3>
-					<ul class="global-footer__links is-advertise">
-						<li class="global-footer__list-item"><a class="global-footer__link is-advertise" href="#">Media Kit</a></li>
-						<li class="global-footer__list-item"><a class="global-footer__link is-advertise" href="#">Contact</a></li>
+					<ul class="global-footer__links">
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Media Kit</a></li>
+						<li class="global-footer__list-item"><a class="global-footer__link" href="#">Contact</a></li>
 					</ul>
 				</section>
 			</div>

--- a/components/footer.scss
+++ b/components/footer.scss
@@ -177,71 +177,77 @@ $global-footer-section-header-margin-bottom: 10px;
 	&:hover {
 		color: $color-white;
 	}
-
-	&.is-create-wiki {
-		border: solid 1px $color-blue-gray;
-		color: $color-blue-gray;
-		display: inline-block;
-		font: {
-			size: $typescale-size-minus-2;
-			weight: bold;
-		}
-		letter-spacing: 0.3px;
-		line-height: normal;
-		margin-top: 13px;
-		padding: 14px 18px;
-		text-decoration: none;
-		text-transform: uppercase;
-
-		&:hover {
-			color: $color-white;
-		}
-	}
-
-	&.is-community-apps {
-		display: block;
-		line-height: normal;
-		margin-top: 6px;
-		width: 119px;
-	}
-
-	&.is-follow-us {
-		$global-footer-social-icon-size: 24px;
-
-		background: no-repeat center;
-		background-size: $global-footer-social-icon-size;
-		display: inline-block;
-		height: $global-footer-social-icon-size;
-		margin-right: 20px;
-		width: $global-footer-social-icon-size;
-	}
 }
 
-.global-footer__links {
-	&.is-community-apps {
-		display: flex;
-	}
-
-	&.is-follow-us {
-		display: flex;
-		flex-wrap: nowrap;
-	}
-}
-
-.global-footer__image {
+.global-footer__fandom-section {
 	&.is-fandom-overview {
-		transform: rotate(180deg);
+		border: 0;
+		padding: 0;
+
+		.global-footer__image {
+			transform: rotate(180deg);
+		}
 	}
 
-	&.is-community-apps {
-		height: 35px;
-		width: 119px;
+	&.is-follow-us {
+		.global-footer__links {
+			display: flex;
+			flex-wrap: nowrap;
+		}
+
+		.global-footer__link {
+			$global-footer-social-icon-size: 24px;
+
+			background: no-repeat center;
+			background-size: $global-footer-social-icon-size;
+			display: inline-block;
+			height: $global-footer-social-icon-size;
+			margin-right: 20px;
+			width: $global-footer-social-icon-size;
+		}
 	}
 }
 
-.global-footer__fandom-section.is-fandom-overview {
-	border: 0;
-	padding: 0;
+.global-footer__wikia-section {
+	&.is-create-wiki {
+		.global-footer__link {
+			border: solid 1px $color-blue-gray;
+			color: $color-blue-gray;
+			display: inline-block;
+			font: {
+				size: $typescale-size-minus-2;
+				weight: bold;
+			}
+			letter-spacing: 0.3px;
+			line-height: normal;
+			margin-top: 13px;
+			padding: 14px 18px;
+			text-decoration: none;
+			text-transform: uppercase;
+
+			&:hover {
+				color: $color-white;
+			}
+		}
+	}
+
+	&.is-community-apps {
+		.global-footer__links {
+			display: flex;
+		}
+
+		.global-footer__link {
+			display: block;
+			line-height: normal;
+			margin-top: 6px;
+			width: 119px;
+		}
+
+		.global-footer__image {
+			height: 35px;
+			width: 119px;
+		}
+	}
 }
 
 .global-footer__section-header {
@@ -319,34 +325,6 @@ $global-footer-section-header-margin-bottom: 10px;
 		}
 	}
 
-	.global-footer__links {
-		.global-footer__list-item {
-			margin-bottom: 10px;
-		}
-
-		&.is-follow-us .global-footer__list-item,
-		&.is-fandom-overview .global-footer__list-item {
-			margin-bottom: 0;
-		}
-
-		&.is-community-apps {
-			margin-top: 5px;
-			margin-bottom: 0;
-		}
-	}
-
-	.global-footer__link {
-		&.is-follow-us {
-			height: 42px;
-			margin-right: 10px;
-			width: 42px;
-		}
-
-		&.is-community-apps {
-			margin-right: 25px;
-		}
-	}
-
 	// left (Fandom) and right (Wikia) sections
 	.global-footer__fandom-section,
 	.global-footer__wikia-section {
@@ -357,6 +335,24 @@ $global-footer-section-header-margin-bottom: 10px;
 	// items in Wikia section
 	.global-footer__wikia-section {
 		margin-bottom: 20px;
+
+		&.is-fandom-overview {
+			.global-footer__list-item {
+				margin-bottom: 0;
+			}
+		}
+
+		&.is-follow-us {
+			.global-footer__list-item {
+				margin-bottom: 0;
+			}
+
+			.global-footer__link {
+				height: 42px;
+				margin-right: 10px;
+				width: 42px;
+			}
+		}
 
 		&.is-company-overview {
 			width: 50%;
@@ -370,12 +366,27 @@ $global-footer-section-header-margin-bottom: 10px;
 		&.is-create-wiki {
 			display: none;
 		}
+
+		&.is-community-apps {
+			.global-footer__links {
+				margin-top: 5px;
+				margin-bottom: 0;
+			}
+
+			.global-footer__link {
+				margin-right: 25px;
+			}
+		}
 	}
 
 	.global-footer.is-international {
 		.global-footer__fandom-section.is-follow-us {
 			margin-bottom: 37px;
 		}
+	}
+
+	.global-footer__list-item {
+		margin-bottom: 10px;
 	}
 
 	.global-footer__licensing-and-vertical {
@@ -390,12 +401,16 @@ $global-footer-section-header-margin-bottom: 10px;
 	}
 
 	// main content
-	.global-footer.is-en .global-footer__main {
-		height: $global-footer-desktop-en-sections-height;
+	.global-footer.is-en {
+		.global-footer__main {
+			height: $global-footer-desktop-en-sections-height;
+		}
 	}
 
-	.global-footer.is-international .global-footer__main {
-		height: $global-footer-desktop-international-sections-height;
+	.global-footer.is-international {
+		.global-footer__main {
+			height: $global-footer-desktop-international-sections-height;
+		}
 	}
 
 	.global-footer__header {
@@ -435,47 +450,49 @@ $global-footer-section-header-margin-bottom: 10px;
 		width: $global-footer-desktop-column-wikia;
 	}
 
-	.global-footer__links.is-community-apps {
-		flex-direction: column;
-		margin-top: 5px;
-	}
-
 	// items in Fandom section
 	.global-footer__fandom-section {
 		width: $global-footer-desktop-first-column-width;
 	}
 
 	// items in Wikia section
-	.global-footer__wikia-section.is-company-overview {
-		height: $global-footer-desktop-row-top-height;
-		margin-right: 50px;
-		width: $global-footer-desktop-second-column-width;
-	}
+	.global-footer__wikia-section {
+		&.is-company-overview {
+			height: $global-footer-desktop-row-top-height;
+			margin-right: 50px;
+			width: $global-footer-desktop-second-column-width;
+		}
 
-	.global-footer__wikia-section.is-site-overview {
-		height: $global-footer-desktop-row-bottom-height;
-		margin-right: 50px;
-		width: $global-footer-desktop-second-column-width;
-	}
+		&.is-site-overview {
+			height: $global-footer-desktop-row-bottom-height;
+			margin-right: 50px;
+			width: $global-footer-desktop-second-column-width;
+		}
 
-	.global-footer__wikia-section.is-community {
-		height: $global-footer-desktop-row-top-height;
-		width: $global-footer-desktop-third-column-width;
-	}
+		&.is-community {
+			height: $global-footer-desktop-row-top-height;
+			width: $global-footer-desktop-third-column-width;
+		}
 
-	.global-footer__wikia-section.is-create-wiki {
-		height: $global-footer-desktop-row-bottom-height;
-		display: block;
-		width: $global-footer-desktop-third-column-width;
-	}
+		&.is-create-wiki {
+			height: $global-footer-desktop-row-bottom-height;
+			display: block;
+			width: $global-footer-desktop-third-column-width;
+		}
 
-	.global-footer__wikia-section.is-community-apps {
-		height: $global-footer-desktop-row-top-height;
-		width: $global-footer-desktop-fourth-column-width;
-	}
+		&.is-community-apps {
+			height: $global-footer-desktop-row-top-height;
+			width: $global-footer-desktop-fourth-column-width;
 
-	.global-footer__wikia-section.is-advertise {
-		height: $global-footer-desktop-row-bottom-height;
-		width: $global-footer-desktop-fourth-column-width;
+			.global-footer__links {
+				flex-direction: column;
+				margin-top: 5px;
+			}
+		}
+
+		&.is-advertise {
+			height: $global-footer-desktop-row-bottom-height;
+			width: $global-footer-desktop-fourth-column-width;
+		}
 	}
 }

--- a/index.html
+++ b/index.html
@@ -2183,11 +2183,11 @@
               </h2>
               <div class="global-footer__fandom-sections">
                 <section class="global-footer__fandom-section is-fandom-overview">
-                  <ul class="global-footer__links is-fandom-overview">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
                       <a href="#" class="global-footer__branded is-games">
                         <div>Games</div>
-                        <svg class="global-footer__image is-fandom-overview icon">
+                        <svg class="global-footer__image icon">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow">
                         </svg>
                       </a>
@@ -2195,7 +2195,7 @@
                     <li class="global-footer__list-item">
                       <a href="#" class="global-footer__branded is-movies">
                         <div>Movies</div>
-                        <svg class="global-footer__image is-fandom-overview icon">
+                        <svg class="global-footer__image icon">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow">
                         </svg>
                       </a>
@@ -2203,7 +2203,7 @@
                     <li class="global-footer__list-item">
                       <a href="#" class="global-footer__branded is-tv">
                         <div>TV</div>
-                        <svg class="global-footer__image is-fandom-overview icon">
+                        <svg class="global-footer__image icon">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow">
                         </svg>
                       </a>
@@ -2211,7 +2211,7 @@
                     <li class="global-footer__list-item">
                       <a href="#" class="global-footer__branded is-fan-communities">
                         <div>Fan Communities</div>
-                        <svg class="global-footer__image is-fandom-overview icon">
+                        <svg class="global-footer__image icon">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow">
                         </svg>
                       </a>
@@ -2220,38 +2220,38 @@
                 </section>
                 <section class="global-footer__fandom-section is-follow-us">
                   <h3 class="global-footer__section-header">Follow Us</h3>
-                  <ul class="global-footer__links is-follow-us">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Facebook">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Facebook">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-facebook-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Twitter">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Twitter">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-twitter-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Reddit">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Reddit">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-reddit-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Youtube">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Youtube">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-youtube-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Instagram">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Instagram">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-instagram-default">
                         </svg>
                       </a>
@@ -2267,57 +2267,57 @@
               <div class="global-footer__wikia-sections">
                 <section class="global-footer__wikia-section is-company-overview">
                   <h3 class="global-footer__section-header">Overview</h3>
-                  <ul class="global-footer__links is-company-overview">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">About</a>
+                      <a class="global-footer__link" href="#">About</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">Careers</a>
+                      <a class="global-footer__link" href="#">Careers</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">News</a>
+                      <a class="global-footer__link" href="#">News</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">Contact</a>
+                      <a class="global-footer__link" href="#">Contact</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">Wikia Gives Back</a>
+                      <a class="global-footer__link" href="#">Wikia Gives Back</a>
                     </li>
                   </ul>
                 </section>
                 <section class="global-footer__wikia-section is-site-overview">
-                  <ul class="global-footer__links is-site-overview">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">Terms Of Use</a>
+                      <a class="global-footer__link" href="#">Terms Of Use</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">Privacy Policy</a>
+                      <a class="global-footer__link" href="#">Privacy Policy</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">Global Sitemap</a>
+                      <a class="global-footer__link" href="#">Global Sitemap</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">API</a>
+                      <a class="global-footer__link" href="#">API</a>
                     </li>
                   </ul>
                 </section>
                 <section class="global-footer__wikia-section is-community">
                   <h3 class="global-footer__section-header">Community</h3>
-                  <ul class="global-footer__links is-community">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Community Central</a>
+                      <a class="global-footer__link" href="#">Community Central</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Support</a>
+                      <a class="global-footer__link" href="#">Support</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Fan Contributor Program</a>
+                      <a class="global-footer__link" href="#">Fan Contributor Program</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">WAM Score</a>
+                      <a class="global-footer__link" href="#">WAM Score</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Help</a>
+                      <a class="global-footer__link" href="#">Help</a>
                     </li>
                   </ul>
                 </section>
@@ -2332,17 +2332,17 @@
                 <section class="global-footer__wikia-section is-community-apps">
                   <h3 class="global-footer__section-header">Community Apps</h3>
                   <span class="global-footer__section-description">Take your favorite fandoms with you and never miss a beat.</span>
-                  <ul class="global-footer__links is-community-apps">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-community-apps">
-                        <svg class="global-footer__image is-community-apps" alt="App Store">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image" alt="App Store">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-appstore">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-community-apps">
-                        <svg class="global-footer__image is-community-apps" alt="Google Play">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image" alt="Google Play">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-googleplay">
                         </svg>
                       </a>
@@ -2351,12 +2351,12 @@
                 </section>
                 <section class="global-footer__wikia-section is-advertise">
                   <h3 class="global-footer__section-header">Advertise</h3>
-                  <ul class="global-footer__links is-advertise">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-advertise" href="#">Media Kit</a>
+                      <a class="global-footer__link" href="#">Media Kit</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-advertise" href="#">Contact</a>
+                      <a class="global-footer__link" href="#">Contact</a>
                     </li>
                   </ul>
                 </section>
@@ -2381,11 +2381,11 @@
             <div class="global-footer__main">
               <div class="global-footer__fandom-sections">
                 <section class="global-footer__fandom-section is-fandom-overview">
-                  <ul class="global-footer__links is-fandom-overview">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
                       <a href="#" class="global-footer__branded is-fan-communities">
                         <div>Fan Communities</div>
-                        <svg class="global-footer__image is-fandom-overview icon">
+                        <svg class="global-footer__image icon">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-arrow">
                         </svg>
                       </a>
@@ -2394,38 +2394,38 @@
                 </section>
                 <section class="global-footer__fandom-section is-follow-us">
                   <h3 class="global-footer__section-header">Follow Us</h3>
-                  <ul class="global-footer__links is-follow-us">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Facebook">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Facebook">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-facebook-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Twitter">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Twitter">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-twitter-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Reddit">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Reddit">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-reddit-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Youtube">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Youtube">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-youtube-default">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-follow-us">
-                        <svg class="global-footer__image is-follow-us icon" alt="Instagram">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image icon" alt="Instagram">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icons-instagram-default">
                         </svg>
                       </a>
@@ -2436,57 +2436,57 @@
               <div class="global-footer__wikia-sections">
                 <section class="global-footer__wikia-section is-company-overview">
                   <h3 class="global-footer__section-header">Overview</h3>
-                  <ul class="global-footer__links is-company-overview">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">About</a>
+                      <a class="global-footer__link" href="#">About</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">Careers</a>
+                      <a class="global-footer__link" href="#">Careers</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">News</a>
+                      <a class="global-footer__link" href="#">News</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">Contact</a>
+                      <a class="global-footer__link" href="#">Contact</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-company-overview" href="#">Wikia Gives Back</a>
+                      <a class="global-footer__link" href="#">Wikia Gives Back</a>
                     </li>
                   </ul>
                 </section>
                 <section class="global-footer__wikia-section is-site-overview">
-                  <ul class="global-footer__links is-site-overview">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">Terms Of Use</a>
+                      <a class="global-footer__link" href="#">Terms Of Use</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">Privacy Policy</a>
+                      <a class="global-footer__link" href="#">Privacy Policy</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">Global Sitemap</a>
+                      <a class="global-footer__link" href="#">Global Sitemap</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-site-overview" href="#">API</a>
+                      <a class="global-footer__link" href="#">API</a>
                     </li>
                   </ul>
                 </section>
                 <section class="global-footer__wikia-section is-community">
                   <h3 class="global-footer__section-header">Community</h3>
-                  <ul class="global-footer__links is-community">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Community Central</a>
+                      <a class="global-footer__link" href="#">Community Central</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Support</a>
+                      <a class="global-footer__link" href="#">Support</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Fan Contributor Program</a>
+                      <a class="global-footer__link" href="#">Fan Contributor Program</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">WAM Score</a>
+                      <a class="global-footer__link" href="#">WAM Score</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-community" href="#">Help</a>
+                      <a class="global-footer__link" href="#">Help</a>
                     </li>
                   </ul>
                 </section>
@@ -2501,17 +2501,17 @@
                 <section class="global-footer__wikia-section is-community-apps">
                   <h3 class="global-footer__section-header">Community Apps</h3>
                   <span class="global-footer__section-description">Take your favorite fandoms with you and never miss a beat.</span>
-                  <ul class="global-footer__links is-community-apps">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-community-apps">
-                        <svg class="global-footer__image is-community-apps" alt="App Store">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image" alt="App Store">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-appstore">
                         </svg>
                       </a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a href="#" class="global-footer__link is-community-apps">
-                        <svg class="global-footer__image is-community-apps" alt="Google Play">
+                      <a href="#" class="global-footer__link">
+                        <svg class="global-footer__image" alt="Google Play">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#company-store-googleplay">
                         </svg>
                       </a>
@@ -2520,12 +2520,12 @@
                 </section>
                 <section class="global-footer__wikia-section is-advertise">
                   <h3 class="global-footer__section-header">Advertise</h3>
-                  <ul class="global-footer__links is-advertise">
+                  <ul class="global-footer__links">
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-advertise" href="#">Media Kit</a>
+                      <a class="global-footer__link" href="#">Media Kit</a>
                     </li>
                     <li class="global-footer__list-item">
-                      <a class="global-footer__link is-advertise" href="#">Contact</a>
+                      <a class="global-footer__link" href="#">Contact</a>
                     </li>
                   </ul>
                 </section>
@@ -2548,11 +2548,11 @@
     <span class="hljs-tag">&lt;/<span class="hljs-title">h2</span>&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__fandom-sections&quot;</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__fandom-section is-fandom-overview&quot;</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-fandom-overview&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
             <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__branded is-games&quot;</span>&gt;</span>
               <span class="hljs-tag">&lt;<span class="hljs-title">div</span>&gt;</span>Games<span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-fandom-overview icon&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-arrow&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2560,7 +2560,7 @@
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
             <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__branded is-movies&quot;</span>&gt;</span>
               <span class="hljs-tag">&lt;<span class="hljs-title">div</span>&gt;</span>Movies<span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-fandom-overview icon&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-arrow&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2568,7 +2568,7 @@
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
             <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__branded is-tv&quot;</span>&gt;</span>
               <span class="hljs-tag">&lt;<span class="hljs-title">div</span>&gt;</span>TV<span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-fandom-overview icon&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-arrow&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2576,7 +2576,7 @@
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
             <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__branded is-fan-communities&quot;</span>&gt;</span>
               <span class="hljs-tag">&lt;<span class="hljs-title">div</span>&gt;</span>Fan Communities<span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-fandom-overview icon&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-arrow&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2585,38 +2585,38 @@
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__fandom-section is-follow-us&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Follow Us<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-follow-us&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Facebook&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Facebook&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-facebook-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Twitter&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Twitter&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-twitter-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Reddit&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Reddit&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-reddit-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Youtube&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Youtube&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-youtube-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Instagram&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Instagram&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-instagram-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2632,57 +2632,57 @@
     <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-sections&quot;</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-company-overview&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Overview<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-company-overview&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>About<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>About<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Careers<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Careers<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>News<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>News<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Wikia Gives Back<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Wikia Gives Back<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-site-overview&quot;</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-site-overview&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Terms Of Use<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Terms Of Use<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Privacy Policy<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Privacy Policy<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Global Sitemap<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Global Sitemap<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>API<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>API<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-community&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Community<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-community&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Community Central<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Community Central<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Support<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Support<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Fan Contributor Program<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Fan Contributor Program<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>WAM Score<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>WAM Score<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Help<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Help<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
@@ -2697,17 +2697,17 @@
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-community-apps&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Community Apps<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-description&quot;</span>&gt;</span>Take your favorite fandoms with you and never miss a beat.<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-community-apps&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community-apps&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-community-apps&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;App Store&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;App Store&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#company-store-appstore&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community-apps&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-community-apps&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Google Play&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Google Play&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#company-store-googleplay&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2716,12 +2716,12 @@
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-advertise&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Advertise<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-advertise&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-advertise&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Media Kit<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Media Kit<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-advertise&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
@@ -2746,11 +2746,11 @@
   <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__main&quot;</span>&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__fandom-sections&quot;</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__fandom-section is-fandom-overview&quot;</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-fandom-overview&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
             <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__branded is-fan-communities&quot;</span>&gt;</span>
               <span class="hljs-tag">&lt;<span class="hljs-title">div</span>&gt;</span>Fan Communities<span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-fandom-overview icon&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-arrow&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2759,38 +2759,38 @@
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__fandom-section is-follow-us&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Follow Us<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-follow-us&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Facebook&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Facebook&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-facebook-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Twitter&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Twitter&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-twitter-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Reddit&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Reddit&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-reddit-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Youtube&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Youtube&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-youtube-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-follow-us&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-follow-us icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Instagram&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image icon&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Instagram&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#icons-instagram-default&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2801,57 +2801,57 @@
     <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-sections&quot;</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-company-overview&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Overview<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-company-overview&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>About<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>About<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Careers<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Careers<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>News<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>News<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-company-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Wikia Gives Back<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Wikia Gives Back<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-site-overview&quot;</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-site-overview&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Terms Of Use<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Terms Of Use<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Privacy Policy<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Privacy Policy<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Global Sitemap<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Global Sitemap<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-site-overview&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>API<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>API<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-community&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Community<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-community&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Community Central<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Community Central<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Support<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Support<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Fan Contributor Program<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Fan Contributor Program<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>WAM Score<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>WAM Score<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Help<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Help<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
@@ -2866,17 +2866,17 @@
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-community-apps&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Community Apps<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-description&quot;</span>&gt;</span>Take your favorite fandoms with you and never miss a beat.<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-community-apps&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community-apps&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-community-apps&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;App Store&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;App Store&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#company-store-appstore&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-community-apps&quot;</span>&gt;</span>
-              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image is-community-apps&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Google Play&quot;</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span>&gt;</span>
+              <span class="hljs-tag">&lt;<span class="hljs-title">svg</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__image&quot;</span> <span class="hljs-attribute">alt</span>=<span class="hljs-value">&quot;Google Play&quot;</span>&gt;</span>
                 <span class="hljs-tag">&lt;<span class="hljs-title">use</span> <span class="hljs-attribute">xmlns:xlink</span>=<span class="hljs-value">&quot;http://www.w3.org/1999/xlink&quot;</span> <span class="hljs-attribute">xlink:href</span>=<span class="hljs-value">&quot;#company-store-googleplay&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">use</span>&gt;</span>
               <span class="hljs-tag">&lt;/<span class="hljs-title">svg</span>&gt;</span>
             <span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
@@ -2885,12 +2885,12 @@
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-title">section</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__wikia-section is-advertise&quot;</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-title">h3</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__section-header&quot;</span>&gt;</span>Advertise<span class="hljs-tag">&lt;/<span class="hljs-title">h3</span>&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links is-advertise&quot;</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-title">ul</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__links&quot;</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-advertise&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Media Kit<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Media Kit<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
           <span class="hljs-tag">&lt;<span class="hljs-title">li</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__list-item&quot;</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link is-advertise&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+            <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">&quot;global-footer__link&quot;</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">&quot;#&quot;</span>&gt;</span>Contact<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
           <span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-title">ul</span>&gt;</span>
       <span class="hljs-tag">&lt;/<span class="hljs-title">section</span>&gt;</span>

--- a/www/index.css
+++ b/www/index.css
@@ -97,7 +97,25 @@
 .global-footer__link:hover {
   color: #fff; }
 
-.global-footer__link.is-create-wiki {
+.global-footer__fandom-section.is-fandom-overview {
+  border: 0;
+  padding: 0; }
+  .global-footer__fandom-section.is-fandom-overview .global-footer__image {
+    transform: rotate(180deg); }
+
+.global-footer__fandom-section.is-follow-us .global-footer__links {
+  display: flex;
+  flex-wrap: nowrap; }
+
+.global-footer__fandom-section.is-follow-us .global-footer__link {
+  background: no-repeat center;
+  background-size: 24px;
+  display: inline-block;
+  height: 24px;
+  margin-right: 20px;
+  width: 24px; }
+
+.global-footer__wikia-section.is-create-wiki .global-footer__link {
   border: solid 1px #c5ced9;
   color: #c5ced9;
   display: inline-block;
@@ -109,40 +127,21 @@
   padding: 14px 18px;
   text-decoration: none;
   text-transform: uppercase; }
-  .global-footer__link.is-create-wiki:hover {
+  .global-footer__wikia-section.is-create-wiki .global-footer__link:hover {
     color: #fff; }
 
-.global-footer__link.is-community-apps {
+.global-footer__wikia-section.is-community-apps .global-footer__links {
+  display: flex; }
+
+.global-footer__wikia-section.is-community-apps .global-footer__link {
   display: block;
   line-height: normal;
   margin-top: 6px;
   width: 119px; }
 
-.global-footer__link.is-follow-us {
-  background: no-repeat center;
-  background-size: 24px;
-  display: inline-block;
-  height: 24px;
-  margin-right: 20px;
-  width: 24px; }
-
-.global-footer__links.is-community-apps {
-  display: flex; }
-
-.global-footer__links.is-follow-us {
-  display: flex;
-  flex-wrap: nowrap; }
-
-.global-footer__image.is-fandom-overview {
-  transform: rotate(180deg); }
-
-.global-footer__image.is-community-apps {
+.global-footer__wikia-section.is-community-apps .global-footer__image {
   height: 35px;
   width: 119px; }
-
-.global-footer__fandom-section.is-fandom-overview {
-  border: 0;
-  padding: 0; }
 
 .global-footer__section-header {
   color: #fff;
@@ -190,26 +189,20 @@
   .global-footer__wikia-header {
     margin-bottom: 29px;
     margin-top: 61px; }
-  .global-footer__links .global-footer__list-item {
-    margin-bottom: 10px; }
-  .global-footer__links.is-follow-us .global-footer__list-item,
-  .global-footer__links.is-fandom-overview .global-footer__list-item {
-    margin-bottom: 0; }
-  .global-footer__links.is-community-apps {
-    margin-top: 5px;
-    margin-bottom: 0; }
-  .global-footer__link.is-follow-us {
-    height: 42px;
-    margin-right: 10px;
-    width: 42px; }
-  .global-footer__link.is-community-apps {
-    margin-right: 25px; }
   .global-footer__fandom-section,
   .global-footer__wikia-section {
     margin: 0;
     width: 100%; }
   .global-footer__wikia-section {
     margin-bottom: 20px; }
+    .global-footer__wikia-section.is-fandom-overview .global-footer__list-item {
+      margin-bottom: 0; }
+    .global-footer__wikia-section.is-follow-us .global-footer__list-item {
+      margin-bottom: 0; }
+    .global-footer__wikia-section.is-follow-us .global-footer__link {
+      height: 42px;
+      margin-right: 10px;
+      width: 42px; }
     .global-footer__wikia-section.is-company-overview {
       width: 50%; }
     .global-footer__wikia-section.is-site-overview {
@@ -217,8 +210,15 @@
       width: 50%; }
     .global-footer__wikia-section.is-create-wiki {
       display: none; }
+    .global-footer__wikia-section.is-community-apps .global-footer__links {
+      margin-top: 5px;
+      margin-bottom: 0; }
+    .global-footer__wikia-section.is-community-apps .global-footer__link {
+      margin-right: 25px; }
   .global-footer.is-international .global-footer__fandom-section.is-follow-us {
     margin-bottom: 37px; }
+  .global-footer__list-item {
+    margin-bottom: 10px; }
   .global-footer__licensing-and-vertical {
     text-align: center; } }
 
@@ -250,9 +250,6 @@
     flex-direction: column;
     height: 393px;
     width: 75%; }
-  .global-footer__links.is-community-apps {
-    flex-direction: column;
-    margin-top: 5px; }
   .global-footer__fandom-section {
     width: 200px; }
   .global-footer__wikia-section.is-company-overview {
@@ -273,6 +270,9 @@
   .global-footer__wikia-section.is-community-apps {
     height: 209px;
     width: 200px; }
+    .global-footer__wikia-section.is-community-apps .global-footer__links {
+      flex-direction: column;
+      margin-top: 5px; }
   .global-footer__wikia-section.is-advertise {
     height: 184px;
     width: 200px; } }


### PR DESCRIPTION
Let's use:

```
HTML:
<section class="global-footer__wikia-section is-company-overview">
    <ul class="global-footer__links">
        <li><a class="global-footer__link" href="#">About</a></li>

SCSS:
.global-footer__wikia-section {
    &.is-company-overview {
        ...

        .global-footer__links { ... }
        .global-footer__link { ... }
    }
}
```

Instead of:

```
HTML:
<section class="global-footer__wikia-section is-company-overview">
    <ul class="global-footer__links is-company-overview">
        <li><a class="global-footer__link is-company-overview" href="#">About</a></li>

SCSS:
.global-footer__wikia-section {
    &.is-company-overview { ... }
}

.global-footer__links {
    &.is-company-overview { ... }
}

.global-footer__link {
    &.is-company-overview { ... }
}
```
